### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/mediumish.js
+++ b/assets/js/mediumish.js
@@ -77,7 +77,8 @@ const loadDeferredStyles = () => {
     const addStylesNode = document.getElementById('deferred-styles');
     if (addStylesNode) {
         const replacement = document.createElement('div');
-        replacement.innerHTML = addStylesNode.textContent;
+        const textNode = document.createTextNode(addStylesNode.textContent);
+        replacement.appendChild(textNode);
         document.body.appendChild(replacement);
         addStylesNode.parentElement.removeChild(addStylesNode);
     }


### PR DESCRIPTION
Fixes [https://github.com/theblazetimes/theblazetimes.github.io/security/code-scanning/1](https://github.com/theblazetimes/theblazetimes.github.io/security/code-scanning/1)

To fix the problem, we need to ensure that the text content is not directly reinterpreted as HTML. Instead, we should create a text node and append it to the DOM, which will treat the content as plain text rather than HTML.

- Replace the assignment of `addStylesNode.textContent` to `replacement.innerHTML` with the creation of a text node using `document.createTextNode`.
- Append the created text node to the `replacement` element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
